### PR TITLE
Make only one extra bytes vlr per dataset

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LAS"
 uuid = "cc498e2a-d443-4943-8f26-2a8a0f3c7cdb"
 authors = ["BenCurran98 <b.curran@fugro.com>"]
-version = "0.1.1"
+version = "0.2.0"
 
 [deps]
 ArchGDAL = "c9ce4bd3-c3d5-55b8-8973-c0e20141b8c3"

--- a/src/LAS.jl
+++ b/src/LAS.jl
@@ -48,7 +48,7 @@ export SpatialInfo, AxisInfo, Range
 
 export LasVariableLengthRecord, get_user_id, get_record_id, get_description, get_data, is_extended
 export GeoKeys, GeoDoubleParamsTag, GeoAsciiParamsTag, OGC_WKT 
-export ClassificationLookup, TextAreaDescription, ExtraBytes, WaveformPacketDescriptor, WaveformDataPackets
+export ClassificationLookup, TextAreaDescription, ExtraBytes, ExtraBytesCollection, WaveformPacketDescriptor, WaveformDataPackets
 export get_horizontal_unit, get_vertical_unit, get_wkt_string
 export get_classes, get_description, set_description!
 export @register_vlr_type, read_vlr_data, extract_vlr_type

--- a/src/constants.jl
+++ b/src/constants.jl
@@ -31,7 +31,7 @@ const ID_SUPERSEDED = UInt16(7)
 const ID_WAVEFORMPACKETDATA = UInt16(65535)
 
 const DEFAULT_LAS_COLUMNS = (:position, :intensity, :classification, :returnnumber, :numberofreturns, :color, :point_source_id, :gps_time, :overlap)
-const ALL_LAS_COLUMNS = SVector{0,Symbol}()
+const ALL_LAS_COLUMNS = nothing
 
 POINT_SCALE = 0.0001
 global const _VLR_TYPE_MAP = Dict()

--- a/src/header.jl
+++ b/src/header.jl
@@ -413,7 +413,7 @@ creation_year(h::LasHeader) = h.creation_year
 
 Get the size of a header `h` in bytes
 """
-header_size(h::LasHeader) = h.header_size
+header_size(h::LasHeader) = Int(h.header_size)
 
 """
     $(TYPEDSIGNATURES)

--- a/test/file_io.jl
+++ b/test/file_io.jl
@@ -497,12 +497,14 @@ end
         save_las(file_name, pc)
         new_las = load_las(file_name, columnnames(pc))
         vlrs = get_vlrs(new_las)
-        # 5 Extra Bytes VLRs for "thing" and 2 VLRs for "other_thing"
-        @test length(vlrs) == 6
-        @test all(map(i -> LAS.name(get_data(vlrs[i])) == "thing [$(i - 1)]", 1:5))
-        @test LAS.name(get_data(vlrs[6])) == "other_thing"
-        @test all(LAS.data_type.(get_data.(vlrs[1:5])) .== Float64)
-        @test LAS.data_type(get_data(vlrs[6])) == Int
+        # 1 Extra Bytes VLR with 5 entries for "thing" and 1 entry for "other_thing"
+        @test length(vlrs) == 1
+        extra_bytes = LAS.get_extra_bytes(get_data(vlrs[1]))
+        @test length(extra_bytes) == 6
+        @test all(map(i -> LAS.name(extra_bytes[i]) == "thing [$(i - 1)]", 1:5))
+        @test LAS.name(extra_bytes[6]) == "other_thing"
+        @test all(LAS.data_type.(extra_bytes[1:5]) .== Float64)
+        @test LAS.data_type(extra_bytes[6]) == Int
         new_pc = get_pointcloud(new_las)
         for col ∈ columnnames(pc)
             @test all(isapprox.(getproperty(new_pc, col), getproperty(pc, col); atol = LAS.POINT_SCALE))

--- a/test/file_io.jl
+++ b/test/file_io.jl
@@ -316,6 +316,7 @@ end
         :point_source_id,
         :gps_time,
         :color,
+        :terrainHeight
     ]
 
     @test length(expected_columns) == length(columnnames(pc))
@@ -493,36 +494,24 @@ end
         other_thing = rand(Int, num_points)
     )
     mktempdir() do tmp
-        file_name = joinpath(tmp, "pc.las")
-        save_las(file_name, pc)
-        new_las = load_las(file_name, columnnames(pc))
-        vlrs = get_vlrs(new_las)
-        # 1 Extra Bytes VLR with 5 entries for "thing" and 1 entry for "other_thing"
-        @test length(vlrs) == 1
-        extra_bytes = LAS.get_extra_bytes(get_data(vlrs[1]))
-        @test length(extra_bytes) == 6
-        @test all(map(i -> LAS.name(extra_bytes[i]) == "thing [$(i - 1)]", 1:5))
-        @test LAS.name(extra_bytes[6]) == "other_thing"
-        @test all(LAS.data_type.(extra_bytes[1:5]) .== Float64)
-        @test LAS.data_type(extra_bytes[6]) == Int
-        new_pc = get_pointcloud(new_las)
-        for col ∈ columnnames(pc)
-            @test all(isapprox.(getproperty(new_pc, col), getproperty(pc, col); atol = LAS.POINT_SCALE))
+        # do this for regular and compressed las
+        for ext ∈ ["las", "laz"]
+            file_name = joinpath(tmp, "pc.$(ext)")
+            save_las(file_name, pc)
+            new_las = load_las(file_name, columnnames(pc))
+            vlrs = get_vlrs(new_las)
+            # 1 Extra Bytes VLR with 5 entries for "thing" and 1 entry for "other_thing"
+            @test length(vlrs) == 1
+            extra_bytes = LAS.get_extra_bytes(get_data(vlrs[1]))
+            @test length(extra_bytes) == 6
+            @test all(map(i -> LAS.name(extra_bytes[i]) == "thing [$(i - 1)]", 1:5))
+            @test LAS.name(extra_bytes[6]) == "other_thing"
+            @test all(LAS.data_type.(extra_bytes[1:5]) .== Float64)
+            @test LAS.data_type(extra_bytes[6]) == Int
+            new_pc = get_pointcloud(new_las)
+            for col ∈ columnnames(pc)
+                @test all(isapprox.(getproperty(new_pc, col), getproperty(pc, col); atol = LAS.POINT_SCALE))
+            end
         end
-    end
-
-    # LASzip doesn't support writing extra bytes, so make sure we handle this gracefully
-    mktempdir() do tmp
-        file_name = joinpath(tmp, "pc.laz")
-        save_las(file_name, pc)
-        new_las = load_las(file_name, ALL_LAS_COLUMNS)
-        new_pc = get_pointcloud(new_las)
-        @test :my_column ∉ columnnames(new_pc)
-        for col ∈ filter(col -> col ∉ (:thing, :other_thing), columnnames(pc))
-            @assert all(isapprox.(getproperty(new_pc, col), getproperty(pc, col); atol = LAS.POINT_SCALE))
-        end
-        @test isempty(get_vlrs(new_las))
-        @test number_of_vlrs(get_header(new_las)) == 0
-        @test point_record_length(get_header(new_las)) == 20
     end
 end


### PR DESCRIPTION
# Properly Treat Extra Bytes VLRs in Dataset

## Description
This is to fix an inconsistency with how we treat Extra Bytes VLRs in our datasets. Previously we would allow multiple extra bytes VLRs (one corresponding to each "extra user field") however to be technically correct this should be one VLR that contains the records for all extra bytes inside its payload.

## Types of Changes

- Bug fix (non-breaking change which fixes an issue)
- Refactor/improvements

## Tasks
_List of tasks you will do to complete the PR_
  - [x] Add new "collection of Extra Bytes" struct
  - [x] Change functionality to only use one collection VLR for extra bytes in I/O methods
  - [x] Fix tests
  - [x] Ensure Extra Bytes can be read and written consistently (simple I/O checks for both LAS and LAZ)

## Review
- [x] Tests
- [x] Documentation
